### PR TITLE
Decode page ID from DOM which id is start from PagePagesLikedByPageSecondaryPagelet_

### DIFF
--- a/src/routes/fb.js
+++ b/src/routes/fb.js
@@ -6,18 +6,42 @@ const { URL } = require('url');
 module.exports = {
   async show(ctx) {
     const alias = _.get(ctx, 'params.id');
-    const data = await axios.get(`https://www.facebook.com/${alias}`, { ...ctx.socks5 });
-    const $ = cheerio.load(data.data);
-    const ios = $('meta[property="al:ios:url"]').attr('content');
+    const urlString = `https://www.facebook.com/${alias}`;
 
-    if (ios) {
-      const url = new URL(ios);
-      const id = url.searchParams.get('id');
-      const pathname = url.pathname.split('/').slice(-1).pop();
+    const url = new URL(urlString);
 
-      ctx.body = _.defaultTo(id, pathname);
-    } else {
-      ctx.status = 404;
+    // The 404 or other network errors would be thrown by axios.
+    const { data } = await axios.get(urlString, {
+      ...ctx.socks5,
+      headers: {
+        authority: 'www.facebook.com',
+        path: encodeURI(url.pathname),
+        method: 'get',
+        accpet: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
+        'sec-fetch-site': 'none',
+        'sec-fetch-user': '?1',
+        'accept-language': 'en-US,en;q=0.9',
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.163 Safari/537.36',
+        'cache-control': 'max-age=0',
+        'upgrade-insecure-requests': 1,
+        'sec-fetch-dest': 'document',
+        'sec-fetch-mode': 'navigate',
+      },
+    });
+    const $ = cheerio.load(data);
+
+    const pageletDOM = $('[id^="PagePagesLikedByPageSecondaryPagelet_"]');
+    if (pageletDOM) {
+      const [, id] = /PagePagesLikedByPageSecondaryPagelet_(\d+)/g.exec(pageletDOM.attr('id')) || [];
+
+      if (id) {
+        ctx.body = id;
+        return;
+      }
+
+      throw new Error('Decode from ID attr failed, the page ID regex needs to be updated');
     }
+
+    throw new Error('Decode from DOM [id^="PagePagesLikedByPageSecondaryPagelet_"] failed, might be unknown page layout');
   },
 };


### PR DESCRIPTION
Facebook removed the old meta tag from the page. There're few options we can get the page ID.

We're talking on https://www.facebook.com/howfunofficial/ as a sample.

### Getting from the DOM element which contains page ID.
```
<div id="PagePagesLikedByPageSecondaryPagelet_572154239502200" data-referrer="PagePagesLikedByPageSecondaryPagelet_572154239502200" data-referrer="PagePagesLikedByPageSecondaryPagelet_572154239502200">
```

### Decode initial data embeded in JavaScript.
```
new (require("ServerJS"))().handle({"define":[["HubbleS....
```
We can get the whole bundle setting or addition data from the JavaScript intiailizser, but it is too complicated for this service which just wanna obtain the page ID.

### Getting payload from `<script type="application/ld+json">` element.
However, it might not exists.

### Summary
Base on the rule of [H93](https://www.w3.org/TR/WCAG20-TECHS/H93.html), getting page ID from id attribute is a concise, general and convension way to implement.